### PR TITLE
GitHub actions / maven package

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,18 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Build with Maven
+      run: mvn -B package
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release/Maven Deploy
+
+on:
+    workflow_dispatch:
+
+jobs:
+    build:
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up JDK 1.8
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 1.8
+                  server-id: github
+                  settings-path: ${{ github.workspace }}
+
+            - name: Set version
+              run: mvn versions:set -DnewVersion=0.2.0-b${{ github.run_number }}
+
+            - name: Build with Maven
+              run: mvn -B package
+
+            - name: Publish to GitHub Packages Apache Maven
+              run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+
+            - name: Create Release
+              id: create_release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: '0.2.0-b${{ github.run_number }}'
+                  release_name: Release 0.2.0-b${{ github.run_number }}
+                  body: |
+                      Changes in this Release
+                        - ...
+
+                  draft: false
+                  prerelease: true
+
+            - name: Upload Release Asset
+              id: upload-release-asset
+              uses: actions/upload-release-asset@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: ./target/fritzapi-0.2.0-b${{ github.run_number }}.jar
+                  asset_name: fritzapi-0.2.0-b${{ github.run_number }}.jar
+                  asset_content_type: application/jar

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .project
 .classpath
 .settings/
+*.iml
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.bausdorf.fritz</groupId>
-	<artifactId>FritzTR064</artifactId>
+	<artifactId>fritzapi</artifactId>
 	<version>0.2.0-SNAPSHOT</version>
-	<name>fritzTR064</name>
+	<name>fritzapi</name>
 	<description>Access AVM TR-064 API on FRITZ!Box</description>
 
 	<properties>
@@ -71,6 +71,26 @@
 					</descriptorRefs>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
+
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub philipparndt Apache Maven Packages</name>
+			<url>https://maven.pkg.github.com/philipparndt/FritzTR064</url>
+		</repository>
+	</distributionManagement>
 </project>


### PR DESCRIPTION
Hi @nick-less 

I've created two GitHub actions for this project.
- `maven.yml` to build/test on commit
- `release.yml`to build/test, publish a maven package to GitHub and create a GitHub release

In case you like to use this, you have to update the `distributionManagement` section in the `pom.xml` to:

```
<distributionManagement>
<repository>
	<id>github</id>
	<name>GitHub nick-less Apache Maven Packages</name>
	<url>https://maven.pkg.github.com/nick-less/FritzTR064</url>
</repository>
</distributionManagement>
```

Feel free to use this actions or just close the PR ;) I currently used a copy of this project in my MQTT bridge but will switch to a normal maven dependency now.