### PR TITLE
Authenticated calls result in 401 failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .settings/
 *.iml
 .idea/
+/.fritzbox

--- a/src/main/java/de/bausdorf/avm/tr064/FritzConnection.java
+++ b/src/main/java/de/bausdorf/avm/tr064/FritzConnection.java
@@ -25,21 +25,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.auth.DigestScheme;
-import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -98,16 +94,7 @@ public class FritzConnection {
 					+ this.pwd);
 			CredentialsProvider credsProvider = new BasicCredentialsProvider();
 			credsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, pwd));
-			AuthCache authCache = new BasicAuthCache();
-			DigestScheme digestScheme = new DigestScheme();
-			digestScheme.overrideParamter("realm", "F!Box SOAP-Auth");
-			digestScheme.overrideParamter("nonce", Long.toString(new Random().nextLong(), 36));
-			digestScheme.overrideParamter("qop", "auth");
-			digestScheme.overrideParamter("nc", "0");
-			digestScheme.overrideParamter("cnonce", DigestScheme.createCnonce());
-			authCache.put(targetHost, digestScheme);
 			context.setCredentialsProvider(credsProvider);
-			context.setAuthCache(authCache);
 			readTR64(scpdUrl);
 		} else {
 			LOG.debug("read igddesc, because credentials are " + this.user + "/" + this.pwd);

--- a/src/main/java/de/bausdorf/avm/tr064/examples/GetCallers.java
+++ b/src/main/java/de/bausdorf/avm/tr064/examples/GetCallers.java
@@ -1,0 +1,81 @@
+/***********************************************************************************************************************
+ *
+ * javaAVMTR064 - open source Java TR-064 API
+ *===========================================
+ *
+ * Copyright 2015 Marin Pollmann <pollmann.m@gmail.com>
+ * 
+ *
+ ***********************************************************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ ***********************************************************************************************************************/
+package de.bausdorf.avm.tr064.examples;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.bausdorf.avm.tr064.Action;
+import de.bausdorf.avm.tr064.FritzConnection;
+import de.bausdorf.avm.tr064.Response;
+import de.bausdorf.avm.tr064.Service;
+
+/**
+ * Tool to retrieve the call list.
+ */
+public class GetCallers extends Tool {
+	private static final Logger LOG = LoggerFactory.getLogger(GetCallers.class);
+	
+	public static void main(String[] args) throws Exception {
+		new GetCallers(args).run();
+	}
+	
+	public GetCallers(String[] args) {
+		super(args);
+	}
+	
+	private void run() throws IOException, NoSuchFieldException {
+		FritzConnection fc = openConnection();
+		
+		getCallers(fc);
+	}
+
+	private void getCallers(FritzConnection fc) throws IOException, NoSuchFieldException {
+		Service service = fc.getService("X_AVM-DE_OnTel:1");
+		Action action = service.getAction("GetCallList");
+		
+		Response response = action.execute();
+		String callListUrl = response.getValueAsString("NewCallListURL");
+
+		System.out.println(callListUrl);
+		
+		URL url = new URL(callListUrl + "&days=2");
+		char[] buffer = new char[4096];
+		try (InputStream in = url.openStream()) {
+			try (InputStreamReader r = new InputStreamReader(in)) {
+				while (true) {
+					int direct = r.read(buffer);
+					if (direct < 0) {
+						break;
+					}
+					
+					System.out.print(String.valueOf(buffer, 0, direct));
+				}
+			}
+		}
+	}
+
+}

--- a/src/main/java/de/bausdorf/avm/tr064/examples/Tool.java
+++ b/src/main/java/de/bausdorf/avm/tr064/examples/Tool.java
@@ -1,0 +1,91 @@
+/***********************************************************************************************************************
+ *
+ * javaAVMTR064 - open source Java TR-064 API
+ *===========================================
+ *
+ * Copyright 2015 Marin Pollmann <pollmann.m@gmail.com>
+ * 
+ *
+ ***********************************************************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ ***********************************************************************************************************************/
+package de.bausdorf.avm.tr064.examples;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.bausdorf.avm.tr064.FritzConnection;
+import de.bausdorf.avm.tr064.ParseException;
+
+/**
+ * Base class for tools based on TR064.
+ */
+public abstract class Tool {
+	private static final Logger LOG = LoggerFactory.getLogger(Tool.class);
+
+	protected final String ip;
+	protected final String user;
+	protected final String password;
+
+	/** 
+	 * Creates a {@link Tool}.
+	 *
+	 * @param args
+	 */
+	public Tool(String[] args) {
+		if( args.length < 2 ) {
+			try {
+				Properties properties = new Properties();
+				properties.load(new FileInputStream(new File(".fritzbox")));
+				
+				ip = properties.getProperty("fritzbox.ip");
+				user = properties.getProperty("fritzbox.user");
+				password = properties.getProperty("fritzbox.password");
+				
+				LOG.info("Connecting to '" + ip +"' with user '" + user + "', using password '" + password.replaceAll(".", "*") +"'.");
+			} catch (IOException ex) {
+				throw new IllegalArgumentException("args: <fb-ip> <password> [user]", ex);
+			}
+		} else {
+			ip = args[0];
+			password = args[1];
+			if( args.length > 2 ) {
+				user = args[2];
+			} else {
+				// Note: When user is null, no authentication is performed.
+				user ="";
+			}
+		}
+	}
+	
+	/** 
+	 * Create a new FritzConnection with username and password.
+	 */
+	protected FritzConnection openConnection() {
+		FritzConnection fc = new FritzConnection(ip,user,password);
+		try {
+			//The connection has to be initiated. This will load the tr64desc.xml respectively igddesc.xml 
+			//and all the defined Services and Actions. 
+			fc.init(null);
+		} catch (IOException | ParseException e2) {
+			//Any HTTP related error.
+			LOG.error(e2.getMessage(), e2);
+		}
+		return fc;
+	}
+
+}


### PR DESCRIPTION
When trying to e.g. retrieve the call list, connection fails with a 401 error (authentication required), even if correct credentials are provided. The problem seems to be the auth cache used in `FritzConnection`. When removing this (useless?) cache, everything works fine. I created another example tool that retrieves the call list from the Fritz!Box to show the problem/verify the solution.