### PR TITLE
Update to Java 8 and add missing dependencies for JDKs greater than version 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,16 @@
 			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+		    <groupId>javax.xml.bind</groupId>
+		    <artifactId>jaxb-api</artifactId>
+		    <version>2.3.1</version>
+		</dependency>
+		<dependency>
+		    <groupId>javax.xml.soap</groupId>
+		    <artifactId>javax.xml.soap-api</artifactId>
+		    <version>1.4.0</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -54,8 +64,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
The library does no longer work with JDKs beyond version 8, since jaxb and javax.xml.soap is no longer part of the JDK. Updated source and target version to 1.8 and added missing dependencies.