### PR TITLE
Fixed examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Response response = action.execute();
 int deviceCount = response.getValueAsInteger("NewTotalAssociations");
 
 ```
-For more examples see: [The Example Folder](tree/master/src/main/java/de/bausdorf/avm/tr064/examples)
+For more examples see: [The Example Folder](src/main/java/de/bausdorf/avm/tr064/examples)
 
 ## Resorces
 * [AVM API Description](http://avm.de/service/schnittstellen/) (German)
-* [Examples](tree/master/src/main/java/de/bausdorf/avm/tr064/examples)
+* [Examples](src/main/java/de/bausdorf/avm/tr064/examples)
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Response response = action.execute();
 int deviceCount = response.getValueAsInteger("NewTotalAssociations");
 
 ```
-For more examples see: [The Example Folder](https://github.com/robbyb/FritzTR064/tree/master/examples)
+For more examples see: [The Example Folder](tree/master/src/main/java/de/bausdorf/avm/tr064/examples)
 
 ## Resorces
 * [AVM API Description](http://avm.de/service/schnittstellen/) (German)
-* [Examples](https://github.com/mirthas/FritzTR064/tree/master/examples)
+* [Examples](tree/master/src/main/java/de/bausdorf/avm/tr064/examples)
 
 ## Thanks
 


### PR DESCRIPTION
The link to the examples folder in the main README was non-relative and pointed to the original (wrong) location.